### PR TITLE
fix(cli): correct bin path to match tsup output

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,9 +1,9 @@
 {
   "name": "create-expo-base",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Scaffold a new Expo project from the expo-base template",
   "bin": {
-    "create-expo-base": "./dist/index.cjs"
+    "create-expo-base": "./dist/index.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
The bin field pointed to dist/index.cjs but tsup outputs dist/index.js, causing npx create-expo-base to fail with "command not found".